### PR TITLE
adjust aknn.ef_construction comain

### DIFF
--- a/rbv2_super/param_set.R
+++ b/rbv2_super/param_set.R
@@ -95,7 +95,7 @@ domain = ps(
     aknn.distance = p_fct(levels = c("l2", "cosine", "ip")),
     aknn.M = p_int(lower = 18L, upper = 50L),
     aknn.ef = p_int(lower = 7L, upper = 403L),
-    aknn.ef_construction = p_int(lower = 7L, upper = 403L),
+    aknn.ef_construction = p_int(lower = 7L, upper = 1097L),
     # xgboost
     xgboost.booster = p_fct(levels = c("gblinear", "gbtree", "dart")),
     xgboost.nrounds = p_int(lower = 7L, upper = 2981L),


### PR DESCRIPTION
For #54

I haven't checked whether the same should be corrected for other search spaces, this one only touches the rbv2_super space! 